### PR TITLE
[Backend] - Implement GET /organizations/:id route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -33,6 +33,22 @@ app.get("/organizations", async (req, res, next) => {
   }
 });
 
+app.get("/organizations/:id", async (req, res, next) => {
+  try {
+    const organization = await prisma.organization.findUnique({
+      where: { id: req.params.id },
+    });
+
+    if (!organization) {
+      return next(createError(404, "Organization not found"));
+    }
+
+    return res.status(200).json({ organization });
+  } catch {
+    return next(createError(500, "Failed to fetch organization"));
+  }
+});
+
 app.use(errorHandler);
 app.listen(PORT, () => {
   console.info(`> Listening on port ${PORT}`);


### PR DESCRIPTION
## Tracking Info

Resolves #17

## Changes

- Added `GET /organizations/:id` in `backend/src/app.ts`.
- Uses `prisma.organization.findUnique({ where: { id } })` to fetch a single organization by UUID.
- Returns `404` with `Organization not found` when no matching record exists.
- Returns `500` with `Failed to fetch organization` on unexpected fetch errors.

## Testing

- Ran `npm run lint-check` in `backend/`.
- Confirmed TypeScript/formatting/lint pass for the updated route file.

## Confirmation of Change

1. Start backend from `backend/` with `npm run start`.
2. Call `GET /organizations/:id` with an existing organization UUID.
3. Verify response is `200` with `{ "organization": { ... } }`.
4. Call with a non-existent UUID and verify `404` with `{ "error": "Organization not found" }`.
