### PR TITLE
[Backend] Implement POST /organizations route

### DIFF
--- a/backend/src/api/organizations.ts
+++ b/backend/src/api/organizations.ts
@@ -1,0 +1,109 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { type NextFunction, type Request, type Response, Router } from "express";
+import createError from "http-errors";
+
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "../config";
+import { prisma } from "../lib/prisma";
+
+const router = Router();
+
+const supabaseAuthUnknown: unknown = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const supabaseAuth = supabaseAuthUnknown as SupabaseClient;
+
+type AuthUserResult = {
+  data: { user: { id: string } } | null;
+  error: Error | null;
+};
+
+type OrganizationBody = {
+  name?: unknown;
+  mission?: unknown;
+  city?: unknown;
+  state?: unknown;
+  country?: unknown;
+  latitude?: unknown;
+  longitude?: unknown;
+  min_budget?: unknown;
+  max_budget?: unknown;
+  tags?: unknown;
+};
+
+async function requireAdminUser(req: Request): Promise<string> {
+  const authHeader = req.headers.authorization;
+
+  if (typeof authHeader !== "string") {
+    throw createError(401, "Missing Authorization header");
+  }
+
+  const [scheme, token] = authHeader.trim().split(/\s+/);
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    throw createError(401, "Missing or invalid Authorization header");
+  }
+
+  const authResult = (await supabaseAuth.auth.getUser(token)) as AuthUserResult;
+  const { data: authData, error: authError } = authResult;
+
+  if (authError || !authData?.user) {
+    throw createError(401, "Invalid or expired token");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { supabase_user_id: authData.user.id },
+    select: { supabase_user_id: true, role: true },
+  });
+
+  if (!user) {
+    throw createError(404, "User does not exist");
+  }
+
+  if (user.role !== "admin") {
+    throw createError(403, "Admin access required");
+  }
+
+  return user.supabase_user_id;
+}
+
+router.get("/organizations", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const organizations = await prisma.organization.findMany();
+    res.status(200).json({ organizations });
+  } catch {
+    next(createError(500, "Failed to fetch organizations"));
+  }
+});
+
+router.post("/organizations", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await requireAdminUser(req);
+
+    const body = req.body as OrganizationBody;
+
+    if (typeof body.name !== "string" || body.name.trim().length === 0) {
+      throw createError(400, "name is required");
+    }
+
+    const organization = await prisma.organization.create({
+      data: {
+        name: body.name.trim(),
+        mission: typeof body.mission === "string" ? body.mission : null,
+        city: typeof body.city === "string" ? body.city : null,
+        state: typeof body.state === "string" ? body.state : null,
+        country: typeof body.country === "string" ? body.country : undefined,
+        latitude: typeof body.latitude === "number" ? body.latitude : null,
+        longitude: typeof body.longitude === "number" ? body.longitude : null,
+        min_budget: typeof body.min_budget === "number" ? Math.trunc(body.min_budget) : null,
+        max_budget: typeof body.max_budget === "number" ? Math.trunc(body.max_budget) : null,
+        tags:
+          Array.isArray(body.tags) && body.tags.every((tag) => typeof tag === "string")
+            ? body.tags
+            : undefined,
+      },
+    });
+
+    res.status(201).json({ organization });
+  } catch (err: unknown) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,10 +1,9 @@
 import cors from "cors";
 import express from "express";
-import createError from "http-errors";
 
+import organizationsRouter from "./api/organizations";
 import apiRouter from "./api/whoami";
 import { FRONTEND_ORIGIN, PORT } from "./config";
-import { prisma } from "./lib/prisma";
 import errorHandler from "./middleware/errorHandler";
 import log from "./middleware/logger";
 
@@ -27,14 +26,7 @@ app.get("/", (req, res) => {
 
 // Mount API routes
 app.use("/api", apiRouter);
-app.get("/organizations", async (req, res, next) => {
-  try {
-    const organizations = await prisma.organization.findMany();
-    res.status(200).json({ organizations });
-  } catch {
-    next(createError(500, "Failed to fetch organizations"));
-  }
-});
+app.use(organizationsRouter);
 
 app.use(errorHandler);
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add a dedicated organizations router and mount it in the backend app
- implement `POST /organizations` with Prisma `organization.create`
- enforce admin-only access by validating Supabase bearer token and checking user role from `users` table
- keep existing `GET /organizations` behavior in the new router

## Testing
- `npx prisma generate`
- `npm run lint-check` (backend)

Closes #20
