### PR TITLE
feat: add NPO exit popup UI

### DIFF
--- a/frontend/src/app/components/NpoExitPopup.tsx
+++ b/frontend/src/app/components/NpoExitPopup.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+type ExitConfirmationProps = {
+  open: boolean;
+  onExit: () => void; // user confirms leaving
+  onContinue: () => void;
+};
+
+export function NpoExitPopup({ open, onExit, onContinue }: ExitConfirmationProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-30 flex items-center justify-center px-4">
+      {/* background overlay */}
+      <div className="absolute inset-0 bg-black/20" />
+
+      {/* popup card */}
+      <div className="relative w-full max-w-[520px] rounded-[20px] bg-white px-8 py-7 shadow-[0_12px_30px_rgba(0,0,0,0.12)]">
+        <h2 className="font-['Proxima_Nova','Helvetica_Neue',Arial,sans-serif] text-[32px] font-bold text-black">
+          Exit?
+        </h2>
+
+        <p className="mt-3 text-[16px] text-[#484848]">
+          If you leave without saving, all your changes will be lost.
+        </p>
+
+        <div className="mt-6 flex items-center gap-4">
+          <button
+            type="button"
+            onClick={onExit}
+            className="rounded-[40px] border border-[#d9d9d9] bg-white px-7 py-2 text-[20px] font-normal text-[#3b9a9a]"
+          >
+            Exit
+          </button>
+
+          <button
+            type="button"
+            onClick={onContinue}
+            className="rounded-[40px] bg-[#3b9a9a] px-7 py-2 text-[16px] text-white"
+          >
+            Continue editing
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+export default NpoExitPopup;

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 
 import "./AdminProfile.css";
 
+// test exit popup for manage npo
+
 export default function AdminProfile() {
   type View = "profile" | "changePassword";
 
@@ -30,6 +32,9 @@ export default function AdminProfile() {
   const [confirmNewPassword, setConfirmNewPassword] = useState("");
   const [pwError, setPwError] = useState("");
   const [pwSavedAt, setPwSavedAt] = useState<string | null>(null);
+
+  // test exit popup for manage npo
+  const [openExitPopup, setOpenExitPopup] = useState(true);
 
   function handleUserInfoChange(key: keyof typeof draftUserInfo, value: string) {
     setDraftUserInfo((prev) => ({ ...prev, [key]: value }));


### PR DESCRIPTION
## Add Exit Popup UI for NPO Profile

Resolves #30 

### Changes

Adds an exit confirmation popup UI to the NPO profile page. This PR focuses on rendering and styling the popup; button actions (navigation/logic) are not yet implemented.

### Testing

-Popup renders correctly
-Layout and styling verified


<img width="1184" height="762" alt="Screenshot 2026-03-27 at 5 46 30 PM" src="https://github.com/user-attachments/assets/73c62a02-7307-4c68-b414-31962fd230b1" />
