### PR TITLE
feat(api): create organization relationship endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ vite.config.ts.timestamp-*
 AGENTS.md
 .cursor/rules/*.mdc
 skills/
+.tools/

--- a/backend/src/api/organizations.ts
+++ b/backend/src/api/organizations.ts
@@ -3,6 +3,7 @@ import { type NextFunction, type Request, type Response, Router } from "express"
 import createError from "http-errors";
 
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from "../config";
+import { Prisma, RelationshipTier } from "../generated/prisma/client.js";
 import { prisma } from "../lib/prisma";
 
 const router = Router();
@@ -21,6 +22,14 @@ type OrganizationBody = {
   sizeCategory?: unknown;
   website?: unknown;
   tags?: unknown;
+};
+
+type OrganizationRelationshipBody = {
+  npo1Id?: unknown;
+  npo2Id?: unknown;
+  relationshipTier?: unknown;
+  relationshipType?: unknown;
+  description?: unknown;
 };
 
 async function requireAdminUser(req: Request): Promise<string> {
@@ -178,5 +187,80 @@ router.post("/organizations", async (req: Request, res: Response, next: NextFunc
     next(err);
   }
 });
+
+router.post(
+  "/organizations/relationships",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await requireAdminUser(req);
+
+      const body = req.body as OrganizationRelationshipBody;
+
+      if (typeof body.npo1Id !== "string" || body.npo1Id.trim().length === 0) {
+        throw createError(400, "npo1Id is required");
+      }
+      if (typeof body.npo2Id !== "string" || body.npo2Id.trim().length === 0) {
+        throw createError(400, "npo2Id is required");
+      }
+
+      const npo1Id = body.npo1Id.trim();
+      const npo2Id = body.npo2Id.trim();
+
+      if (npo1Id === npo2Id) {
+        throw createError(400, "npo1Id and npo2Id must be different organizations");
+      }
+
+      if (typeof body.relationshipTier !== "string") {
+        throw createError(400, "relationshipTier is required");
+      }
+      const relationshipTierRaw = body.relationshipTier.trim();
+      const relationshipTier = (RelationshipTier as Record<string, RelationshipTier>)[
+        relationshipTierRaw
+      ];
+      if (!relationshipTier) {
+        throw createError(400, "relationshipTier must be one of PRIMARY, SECONDARY, TERTIARY");
+      }
+
+      const relationshipType =
+        typeof body.relationshipType === "string" ? body.relationshipType.trim() || null : null;
+      const description =
+        typeof body.description === "string" ? body.description.trim() || null : null;
+
+      const organizations = await prisma.organization.findMany({
+        where: { id: { in: [npo1Id, npo2Id] } },
+        select: { id: true },
+      });
+
+      const found = new Set(organizations.map((o) => o.id));
+      if (!found.has(npo1Id)) {
+        throw createError(404, `Organization ${npo1Id} not found`);
+      }
+      if (!found.has(npo2Id)) {
+        throw createError(404, `Organization ${npo2Id} not found`);
+      }
+
+      try {
+        const relationship = await prisma.organizationRelationship.create({
+          data: {
+            npo1Id,
+            npo2Id,
+            relationshipTier,
+            relationshipType,
+            description,
+          },
+        });
+
+        res.status(201).json({ relationship });
+      } catch (err: unknown) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+          throw createError(409, "That relationship already exists");
+        }
+        throw err;
+      }
+    } catch (err: unknown) {
+      next(err);
+    }
+  },
+);
 
 export default router;

--- a/frontend/src/components/AddNpoPopup.tsx
+++ b/frontend/src/components/AddNpoPopup.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useId, useRef, useState } from "react";
 
 import styles from "./AddNpoPopup.module.css";
@@ -196,7 +197,14 @@ export default function AddNpoPopup({
             <div className={styles.mediaGrid} onDrop={handleDrop} onDragOver={handleDragOver}>
               {mediaFiles.map((item) => (
                 <div key={item.id} className={styles.mediaCard}>
-                  <img src={item.previewUrl} alt={item.file.name} className={styles.mediaImage} />
+                  <Image
+                    src={item.previewUrl}
+                    alt={item.file.name}
+                    className={styles.mediaImage}
+                    width={160}
+                    height={160}
+                    unoptimized
+                  />
                   <button
                     type="button"
                     className={styles.mediaDeleteButton}

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -14,9 +14,9 @@ import {
 } from "./icons/AppIcons";
 import NpoProfileCard from "./NpoProfileCard";
 
-import type React from "react";
-import type { GraphCanvasProps, GraphCanvasRef, InternalGraphNode } from "reagraph";
 import type { APIResult } from "@/api/request";
+import type React from "react";
+import type { GraphCanvasProps } from "reagraph";
 
 import {
   getOrganizationById,
@@ -32,11 +32,27 @@ import {
 // types drop the ref signature, even though Next preserves refs at
 // runtime. Without this cast, passing `ref` to <GraphCanvas /> would
 // fail to type-check.
-const GraphCanvas = dynamic<GraphCanvasProps>(async () => (await import("reagraph")).GraphCanvas, {
-  ssr: false,
-}) as unknown as React.ForwardRefExoticComponent<
-  GraphCanvasProps & React.RefAttributes<GraphCanvasRef>
->;
+type GraphCanvasHandle = {
+  fitNodesInView: (nodeIds?: string[], options?: { animated?: boolean }) => void;
+};
+
+type GraphNodeEvent = {
+  id: string;
+  position: { x: number; y: number };
+};
+
+const loadGraphCanvas = async (): Promise<
+  React.ForwardRefExoticComponent<GraphCanvasProps & React.RefAttributes<GraphCanvasHandle>>
+> => {
+  const mod = (await import("reagraph")) as unknown as {
+    GraphCanvas: React.ForwardRefExoticComponent<
+      GraphCanvasProps & React.RefAttributes<GraphCanvasHandle>
+    >;
+  };
+  return mod.GraphCanvas;
+};
+
+const GraphCanvas = dynamic(loadGraphCanvas, { ssr: false });
 
 // Node/edge shapes accepted by reagraph. `fx`/`fy` pin a node's position in
 // the force-directed layout so we can compute a custom tree silhouette.
@@ -257,7 +273,7 @@ export default function GraphPage() {
   // Imperative handle to the reagraph canvas. Used to re-fit the camera on
   // the currently rendered nodes whenever the search filter changes the
   // visible set (or on initial load).
-  const graphRef = useRef<GraphCanvasRef | null>(null);
+  const graphRef = useRef<GraphCanvasHandle | null>(null);
 
   const selectedOrganization = useMemo(
     () => organizations.find((org) => org.id === selectedOrgId) ?? null,
@@ -506,7 +522,7 @@ export default function GraphPage() {
   // Drag handler: translate the dragged node AND every descendant by the
   // same delta so an entire branch of the tree moves as a unit.
   const handleNodeDragged = useCallback(
-    (node: InternalGraphNode) => {
+    (node: GraphNodeEvent) => {
       setPositions((previousPositions) => {
         const previous = previousPositions.get(node.id);
         if (!previous) return previousPositions;
@@ -538,7 +554,7 @@ export default function GraphPage() {
   // Clicking the same node again toggles the overlay closed, matching the
   // list view's behavior where re-clicking the active row collapses it.
   const handleNodeClick = useCallback(
-    (node: InternalGraphNode) => {
+    (node: GraphNodeEvent) => {
       if (selectedOrgId === node.id && isCardVisible) {
         detailAbortRef.current?.abort();
         setIsCardVisible(false);


### PR DESCRIPTION
Adds an admin-only POST route to create organization relationships, with validation and duplicate handling. Also updates frontend components to pass lint-check.

Finishes #73 