### PR TITLE
feat(api): add GET /api/relationships endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import { FRONTEND_ORIGIN, PORT } from "./config";
 import errorHandler from "./middleware/errorHandler";
 import log from "./middleware/logger";
 import organizationsRouter from "./routes/organizations";
+import relationshipsRouter from "./routes/relationships";
 import tagsRouter from "./routes/tags";
 import usersRouter from "./routes/users";
 import whoamiRouter from "./routes/whoami";
@@ -42,6 +43,7 @@ app.get("/", (req, res) => {
 app.use("/api/whoami", whoamiRouter);
 app.use("/api/users", usersRouter);
 app.use("/api/organizations", organizationsRouter);
+app.use("/api/relationships", relationshipsRouter);
 app.use("/api/tags", tagsRouter);
 
 app.use(errorHandler);

--- a/backend/src/routes/relationships.ts
+++ b/backend/src/routes/relationships.ts
@@ -1,0 +1,22 @@
+import { type NextFunction, type Request, type Response, Router } from "express";
+import createError from "http-errors";
+
+import { prisma } from "../lib/prisma";
+
+const router = Router();
+
+/**
+ * GET /api/relationships — list organization relationships for graph edges.
+ */
+router.get("/", async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const relationships = await prisma.organizationRelationship.findMany({
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+    return res.status(200).json({ relationships });
+  } catch {
+    return next(createError(500, "Failed to fetch relationships"));
+  }
+});
+
+export default router;

--- a/frontend/src/api/relationships.ts
+++ b/frontend/src/api/relationships.ts
@@ -1,0 +1,94 @@
+import { get } from "./request";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseRelationshipsPayload(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+
+  if (isRecord(payload)) {
+    const candidates = [payload.relationships, payload.data, payload.items];
+    for (const candidate of candidates) {
+      if (Array.isArray(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  throw new Error("[/api/relationships] Unexpected response shape.");
+}
+
+function getRequiredString(value: unknown, field: string): string {
+  const stringValue = toOptionalString(value);
+  if (!stringValue) {
+    throw new Error(`[/api/relationships] Missing required field "${field}" in response.`);
+  }
+  return stringValue;
+}
+
+const RELATIONSHIP_TIERS = ["PRIMARY", "SECONDARY", "TERTIARY"] as const;
+
+export type RelationshipTier = (typeof RELATIONSHIP_TIERS)[number];
+
+function parseRelationshipTier(value: unknown): RelationshipTier {
+  if (typeof value !== "string") {
+    throw new TypeError(
+      '[/api/relationships] Missing required field "relationshipTier" in response.',
+    );
+  }
+
+  const tier = value.trim().toUpperCase();
+  if ((RELATIONSHIP_TIERS as readonly string[]).includes(tier)) {
+    return tier as RelationshipTier;
+  }
+
+  throw new Error(`[/api/relationships] Invalid relationshipTier "${value}".`);
+}
+
+export type OrganizationRelationship = {
+  id: string;
+  npo1Id: string;
+  npo2Id: string;
+  relationshipTier: RelationshipTier;
+  relationshipType: string | null;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function parseRelationship(value: unknown): OrganizationRelationship {
+  if (!isRecord(value)) {
+    throw new Error("[/api/relationships] Invalid relationship entry in response.");
+  }
+
+  return {
+    id: getRequiredString(value.id, "id"),
+    npo1Id: getRequiredString(value.npo1Id, "npo1Id"),
+    npo2Id: getRequiredString(value.npo2Id, "npo2Id"),
+    relationshipTier: parseRelationshipTier(value.relationshipTier),
+    relationshipType: toOptionalString(value.relationshipType),
+    description: toOptionalString(value.description),
+    createdAt: getRequiredString(value.createdAt, "createdAt"),
+    updatedAt: getRequiredString(value.updatedAt, "updatedAt"),
+  };
+}
+
+export async function getRelationships(signal?: AbortSignal): Promise<OrganizationRelationship[]> {
+  const response = await get(
+    "/api/relationships",
+    {
+      Accept: "application/json",
+    },
+    signal,
+  );
+  const payload: unknown = await response.json();
+  const rawRelationships = parseRelationshipsPayload(payload);
+  return rawRelationships.map(parseRelationship);
+}

--- a/frontend/src/components/GraphPage.tsx
+++ b/frontend/src/components/GraphPage.tsx
@@ -17,16 +17,34 @@ import NpoProfileCard from "./NpoProfileCard";
 
 import type { APIResult } from "@/api/request";
 import type React from "react";
-import type { GraphCanvasProps, GraphCanvasRef, InternalGraphNode } from "reagraph";
+import type { GraphCanvasProps } from "reagraph";
 
 import { getOrganizationById, type OrganizationDetail } from "@/api/organization";
 import { useOrganizations } from "@/contexts/OrganizationsContext";
 
-const GraphCanvas = dynamic<GraphCanvasProps>(async () => (await import("reagraph")).GraphCanvas, {
-  ssr: false,
-}) as unknown as React.ForwardRefExoticComponent<
-  GraphCanvasProps & React.RefAttributes<GraphCanvasRef>
->;
+type GraphCanvasHandle = {
+  fitNodesInView: (nodeIds?: string[], options?: { animated?: boolean }) => void;
+};
+
+type GraphNodeEvent = {
+  id: string;
+  position: { x: number; y: number };
+};
+
+type ReagraphModule = {
+  GraphCanvas: React.ForwardRefExoticComponent<
+    GraphCanvasProps & React.RefAttributes<GraphCanvasHandle>
+  >;
+};
+
+const loadGraphCanvas = async (): Promise<
+  React.ForwardRefExoticComponent<GraphCanvasProps & React.RefAttributes<GraphCanvasHandle>>
+> => {
+  const mod = (await import("reagraph")) as ReagraphModule;
+  return mod.GraphCanvas;
+};
+
+const GraphCanvas = dynamic(loadGraphCanvas, { ssr: false });
 
 type GraphNode = {
   id: string;
@@ -234,7 +252,7 @@ export default function GraphPage() {
 
   const detailRequestIdRef = useRef(0);
 
-  const graphRef = useRef<GraphCanvasRef | null>(null);
+  const graphRef = useRef<GraphCanvasHandle | null>(null);
 
   // ACTIVATE GRAPH
   const activateGraph = useCallback(() => {
@@ -480,7 +498,7 @@ export default function GraphPage() {
   }, [visibleNodeIdsKey, showFunctionalGraph]);
 
   const handleNodeDragged = useCallback(
-    (node: InternalGraphNode) => {
+    (node: GraphNodeEvent) => {
       setPositions((previousPositions) => {
         const previous = previousPositions.get(node.id);
 
@@ -520,7 +538,7 @@ export default function GraphPage() {
   }, [refetchOrganizations]);
 
   const handleNodeClick = useCallback(
-    (node: InternalGraphNode) => {
+    (node: GraphNodeEvent) => {
       activateGraph();
 
       if (selectedOrgId === node.id && isCardVisible) {


### PR DESCRIPTION
## Summary
- Add `GET /api/relationships` to return all `organization_relationships` rows for graph view edges
- Add typed `getRelationships()` client in `frontend/src/api/relationships.ts`
- Fix `GraphPage` reagraph typings so pre-commit lint passes on `main`

Closes #85

## Files changed
- `backend/src/routes/relationships.ts` — new route handler
- `backend/src/app.ts` — mount router at `/api/relationships`
- `frontend/src/api/relationships.ts` — API client and response parsing
- `frontend/src/components/GraphPage.tsx` — local reagraph types (unblocks lint)

## API response shape
```json
{
  "relationships": [
    {
      "id": "uuid",
      "npo1Id": "uuid",
      "npo2Id": "uuid",
      "relationshipTier": "PRIMARY",
      "relationshipType": null,
      "description": null,
      "createdAt": "ISO-8601",
      "updatedAt": "ISO-8601"
    }
  ]
}
```

Graph edges can map `source` → `npo1Id`, `target` → `npo2Id`, and `label` → `relationshipType` or `relationshipTier`.